### PR TITLE
Fixes #84512

### DIFF
--- a/lib/ansible/modules/service_facts.py
+++ b/lib/ansible/modules/service_facts.py
@@ -211,7 +211,7 @@ class ServiceScanService(BaseService):
 
     def _list_openrc(self, services):
         all_services_runlevels = {}
-        rc, stdout, stderr = self.module.run_command("%s -a -s -m 2>&1 | grep '^ ' | tr -d '[]'" % self.rc_status_path, use_unsafe_shell=True)
+        rc, stdout, stderr = self.module.run_command("%s -a -s -m 2>&1 | grep '^ ' | grep -v '*' | tr -d '[]'" % self.rc_status_path, use_unsafe_shell=True)
         rc_u, stdout_u, stderr_u = self.module.run_command("%s show -v 2>&1 | grep '|'" % self.rc_update_path, use_unsafe_shell=True)
         for line in stdout_u.split('\n'):
             line_data = line.split('|')


### PR DESCRIPTION
##### SUMMARY
Fixes #84512

##### ISSUE TYPE
- Bugfix Pull Request

##### ADDITIONAL INFORMATION

```rc-status -a -s -m 2>&1```

in line 198 may return a row like:

```Caching service dependencies [*]```

Which is unexpected in line 216 of service_facts.py and fails with
```
KeyError: '*'
```

The patch removes lines with '*' which cannot be a run level or a service name.
